### PR TITLE
Transparently capture the status code from other plugins

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -21,13 +21,17 @@ func (m *Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error)
 	// Record response to get status code and size of the reply.
 	rw := httpserver.NewResponseRecorder(w)
 	status, err := next.ServeHTTP(rw, r)
-	// proxies return a status code of 0 but the actual status is available on rw
-	if status == 0 {
-		status = rw.Status()
-	}
-	// Some middlewares set the status to 0, but return an non nil error: map these to status 500
+
+	// Transparently capture the status code so as to not side effect other plugins
+	stat := status
 	if err != nil && status == 0 {
-		status = 500
+		// Some middlewares set the status to 0, but return an non nil error: map these to status 500
+		stat = 500
+	} else if status == 0 {
+		// 'proxy' returns a status code of 0, but the actual status is available on rw.
+		// Note that if 'proxy' encounters an error, it returns the appropriate status code (such as 502)
+		// from ServeHTTP and is captured above with 'stat := status'.
+		stat = rw.Status()
 	}
 
 	fam := "1"
@@ -41,7 +45,7 @@ func (m *Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error)
 	requestCount.WithLabelValues(host, fam, proto).Inc()
 	requestDuration.WithLabelValues(host, fam, proto).Observe(float64(time.Since(start)) / float64(time.Second))
 	responseSize.WithLabelValues(host).Observe(float64(rw.Size()))
-	responseStatus.WithLabelValues(host, strconv.Itoa(status)).Inc()
+	responseStatus.WithLabelValues(host, strconv.Itoa(stat)).Inc()
 
 	return status, err
 }


### PR DESCRIPTION
Fixes #27 

This change ensures that the Prometheus plugin does not side effect other plugins which interpret the status code returned from `ServeHTTP` in various ways. For example, some plugins, like errors (caddy/caddyhttp/errors/errors.go), interpret status code 0 as an already-written response. If the proxy plugin returns 0 and this plugin changes the status code to something other than 0, unexpected behavior can result. 