### PR TITLE
Added a hostname parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ prometheus
 
 For each virtual host that you want to see metrics for.
 
-It optionally takes an address where the metrics are exported, the default
-is `localhost:9180`. The metrics path is fixed to `/metrics`.
+There are currently two optional parameters that can be used:
+
+  - **address** - the address where the metrics are exposed, the default is `localhost:9180`
+  - **hostname** - the hostname that the metrics are generated for, this defaults to your specified hostname
+
+The metrics path is fixed to `/metrics`.
 
 With `caddyext` you'll need to put this module early in the chain, so that
 the duration histogram actually makes sense. I've put it at number 0.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For each virtual host that you want to see metrics for.
 There are currently two optional parameters that can be used:
 
   - **address** - the address where the metrics are exposed, the default is `localhost:9180`
-  - **hostname** - the hostname that the metrics are generated for, this defaults to your specified hostname
+  - **hostname** - the `host` parameter that can be found in the exported metrics, this defaults to the label specified for the server block
 
 The metrics path is fixed to `/metrics`.
 

--- a/handler.go
+++ b/handler.go
@@ -12,9 +12,16 @@ import (
 
 func (m *Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	next := m.next
-	host, err := host(r)
-	if err != nil {
-		host = "-"
+
+	hostname := m.hostname
+
+	if hostname == "" {
+		originalHostname, err := host(r)
+		if err != nil {
+			hostname = "-"
+		} else {
+			hostname = originalHostname
+		}
 	}
 	start := time.Now()
 
@@ -42,10 +49,10 @@ func (m *Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error)
 	proto := strconv.Itoa(r.ProtoMajor)
 	proto = proto + "." + strconv.Itoa(r.ProtoMinor)
 
-	requestCount.WithLabelValues(host, fam, proto).Inc()
-	requestDuration.WithLabelValues(host, fam, proto).Observe(float64(time.Since(start)) / float64(time.Second))
-	responseSize.WithLabelValues(host).Observe(float64(rw.Size()))
-	responseStatus.WithLabelValues(host, strconv.Itoa(stat)).Inc()
+	requestCount.WithLabelValues(hostname, fam, proto).Inc()
+	requestDuration.WithLabelValues(hostname, fam, proto).Observe(float64(time.Since(start)) / float64(time.Second))
+	responseSize.WithLabelValues(hostname).Observe(float64(rw.Size()))
+	responseStatus.WithLabelValues(hostname, strconv.Itoa(stat)).Inc()
 
 	return status, err
 }

--- a/setup.go
+++ b/setup.go
@@ -29,6 +29,7 @@ var once sync.Once
 type Metrics struct {
 	next httpserver.Handler
 	addr string // where to we listen
+	hostname string
 	// subsystem?
 	once sync.Once
 }
@@ -104,6 +105,12 @@ func parse(c *caddy.Controller) (*Metrics, error) {
 					return nil, c.ArgErr()
 				}
 				metrics.addr = args[0]
+			case "hostname":
+				args = c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				metrics.hostname = args[0]
 			default:
 				return nil, c.Errf("prometheus: unknown item: %s", c.Val())
 			}


### PR DESCRIPTION
This PR adds a `hostname` parameter to the configuration, enabling differentiation between two sites hosted on the same domain.

Consider the following example:

```
http://127.0.0.1:1234 {
	prometheus
}

http://127.0.0.1:4567 {
	prometheus
}
```

Previously these two would have been indifferent in the generated metrics. They would both count towards stats with the parameter as host="127.0.0.1".

This PR adds a `hostname` parameter, which can be specified if wanted, allowing the following:

```
http://127.0.0.1:1234 {
	prometheus {
		hostname local-1
	}
}

http://127.0.0.1:4567 {
	prometheus {
		hostname local-2
	}
}
```

Now two different hosts running on the same domain or IP can be differentiated via their `host` parameter.

There should not be any conflicts with existing configurations as this parameter is completely new and optional.

This is pretty much the first bit of Go that I have written, so I'd appreciate any criticism or corrections if I did anything wrong.