### PR TITLE
Allow listening to Caddy's address

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ prometheus
 
 For each virtual host that you want to see metrics for.
 
-There are currently two optional parameters that can be used:
+These are the (optional) parameters that can be used:
 
+  - **use_caddy_addr** - causes metrics to be exposed at the same address:port as Caddy itself. This can not be specified at the same time as **address**.
   - **address** - the address where the metrics are exposed, the default is `localhost:9180`
   - **hostname** - the `host` parameter that can be found in the exported metrics, this defaults to the label specified for the server block
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"net/http/httptest"
 
 	"github.com/mholt/caddy/caddyhttp/httpserver"
@@ -91,9 +93,10 @@ func TestMetrics_ServeHTTP(t *testing.T) {
 	}
 
 	m := &Metrics{
-		next: tests[0].fields.next,
-		addr: tests[0].fields.addr,
-		once: sync.Once{},
+		next:    tests[0].fields.next,
+		addr:    tests[0].fields.addr,
+		once:    sync.Once{},
+		handler: promhttp.Handler(),
 	}
 	m.start()
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,57 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		expected  *Metrics
+	}{
+		{`prometheus`, false, &Metrics{}},
+		{`prometheus foo`, false, &Metrics{addr: "foo"}},
+		{`prometheus foo bar`, true, nil},
+		{`prometheus {
+			a b
+		}`, true, nil},
+		{`prometheus
+			prometheus`, true, nil},
+		{`prometheus {
+			address
+		}`, true, nil},
+		{`prometheus {
+			hostname
+		}`, true, nil},
+		{`prometheus {
+			address 0.0.0.0:1234
+			use_caddy_addr
+		}`, true, nil},
+		{`prometheus {
+			use_caddy_addr
+			address 0.0.0.0:1234
+		}`, true, nil},
+		{`prometheus {
+			use_caddy_addr
+		}`, false, &Metrics{useCaddyAddr: true}},
+		{`prometheus {
+			use_caddy_addr
+			hostname example.com
+		}`, false, &Metrics{useCaddyAddr: true, hostname: "example.com"}},
+	}
+	for i, test := range tests {
+		c := caddy.NewTestController("http", test.input)
+		m, err := parse(c)
+		if test.expected != m && *test.expected != *m {
+			t.Errorf("Test %v: Created Metrics (\n%#v\n) does not match expected (\n%#v\n)", i, m, test.expected)
+		}
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %v: Expected error but found nil", i)
+		} else if !test.shouldErr && err != nil {
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #30 

This allows listening to the same port as Caddy, to simplify certain use-cases (allows binding to a single port instead of two).

I was going to change the default when no address is provided, but that would break existing configurations. Instead I've added an additional boolean parameter `use_caddy_addr` which will enable this feature. IMO it would be less surprising to enable this by default, but there seems not to be a good system for versioning Caddy plugins 🤷‍♂️ 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>