### PR TITLE
Adding support for specifying a custom metrics path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ These are the (optional) parameters that can be used:
 
   - **use_caddy_addr** - causes metrics to be exposed at the same address:port as Caddy itself. This can not be specified at the same time as **address**.
   - **address** - the address where the metrics are exposed, the default is `localhost:9180`
+  - **path** - the path to serve collected metrics from, the default is `/metrics`
   - **hostname** - the `host` parameter that can be found in the exported metrics, this defaults to the label specified for the server block
-
-The metrics path is fixed to `/metrics`.
 
 With `caddyext` you'll need to put this module early in the chain, so that
 the duration histogram actually makes sense. I've put it at number 0.

--- a/handler_test.go
+++ b/handler_test.go
@@ -97,6 +97,7 @@ func TestMetrics_ServeHTTP(t *testing.T) {
 		addr:    tests[0].fields.addr,
 		once:    sync.Once{},
 		handler: promhttp.Handler(),
+		path:    "/metrics",
 	}
 	m.start()
 


### PR DESCRIPTION
Sometimes it's handy to be able to specify a path other than `/metrics`. This PR implements a `path` parameter to allow this.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>