### PR TITLE
Adding basic auth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,32 @@ These are the (optional) parameters that can be used:
   - **address** - the address where the metrics are exposed, the default is `localhost:9180`
   - **path** - the path to serve collected metrics from, the default is `/metrics`
   - **hostname** - the `host` parameter that can be found in the exported metrics, this defaults to the label specified for the server block
+  - **basicauth** - the `basicauth` adds a basic auth check before exposing metrics. It can be defined multiple times.
 
 With `caddyext` you'll need to put this module early in the chain, so that
 the duration histogram actually makes sense. I've put it at number 0.
+
+### Example
+
+```
+:80 {
+
+  ...
+
+  prometheus {
+    address 0.0.0.0:9180
+    path /a/b/c/metrics
+
+    hostname example.org
+
+    basicauth my_username1 my_password1
+    basicauth my_username2 my_password2
+  }
+
+  ...
+
+}
+```
 
 ## Metrics
 

--- a/setup.go
+++ b/setup.go
@@ -51,7 +51,6 @@ func NewMetrics() *Metrics {
 	return &Metrics{
 		path:      defaultPath,
 		addr:      defaultAddr,
-		basicAuth: []BasicAuth{},
 	}
 }
 
@@ -94,7 +93,7 @@ func (m *Metrics) authMiddleware() http.Handler {
 
 	// auth middleware starts here
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if len(m.basicAuth) > 0 {
+		if m.basicAuth != nil && len(m.basicAuth) > 0 {
 
 			// parse 'Authorization' header
 			username, password, ok := r.BasicAuth()

--- a/setup.go
+++ b/setup.go
@@ -26,6 +26,12 @@ const (
 
 var once sync.Once
 
+// BasicAuth holds basic auth credentials
+type BasicAuth struct {
+	username string
+	password string
+}
+
 // Metrics holds the prometheus configuration.
 type Metrics struct {
 	next         httpserver.Handler
@@ -33,6 +39,7 @@ type Metrics struct {
 	useCaddyAddr bool
 	hostname     string
 	path         string
+	basicAuth    []BasicAuth
 	// subsystem?
 	once sync.Once
 
@@ -42,8 +49,9 @@ type Metrics struct {
 // NewMetrics -
 func NewMetrics() *Metrics {
 	return &Metrics{
-		path: defaultPath,
-		addr: defaultAddr,
+		path:      defaultPath,
+		addr:      defaultAddr,
+		basicAuth: []BasicAuth{},
 	}
 }
 
@@ -69,16 +77,58 @@ func (m *Metrics) start() error {
 	return nil
 }
 
+func (m *Metrics) authMiddleware() http.Handler {
+	// if provided credentials match, this handler will be served
+	promHandler := promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+		ErrorLog:      log.New(os.Stderr, "", log.LstdFlags),
+	})
+
+	// authFunc checks if username+password match
+	authFunc := func(givenUsername string, givenPassword string, requiredCred BasicAuth) bool {
+		if givenUsername != requiredCred.username || givenPassword != requiredCred.password {
+			return false
+		}
+		return true
+	}
+
+	// auth middleware starts here
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(m.basicAuth) > 0 {
+
+			// parse 'Authorization' header
+			username, password, ok := r.BasicAuth()
+
+			isAuth := false
+			if ok {
+				for _, cred := range m.basicAuth {
+					if authFunc(username, password, cred) == false {
+						continue
+					}
+					isAuth = true
+				}
+			}
+
+			// auth failed, let's return realm
+			if isAuth == false {
+				w.Header().Set("WWW-Authenticate", "Basic realm=\"Restricted area\"")
+				http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+				return
+			}
+		}
+
+		// auth looks good, we can serve prometheus metrics safely
+		promHandler.ServeHTTP(w, r)
+	})
+}
+
 func setup(c *caddy.Controller) error {
 	metrics, err := parse(c)
 	if err != nil {
 		return err
 	}
 
-	metrics.handler = promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
-		ErrorHandling: promhttp.HTTPErrorOnError,
-		ErrorLog:      log.New(os.Stderr, "", log.LstdFlags),
-	})
+	metrics.handler = metrics.authMiddleware()
 
 	once.Do(func() {
 		c.OnStartup(metrics.start)
@@ -157,6 +207,12 @@ func parse(c *caddy.Controller) (*Metrics, error) {
 					return nil, c.Err("prometheus: address and use_caddy_addr options may not be used together")
 				}
 				metrics.useCaddyAddr = true
+			case "basicauth":
+				args = c.RemainingArgs()
+				if len(args) != 2 {
+					return nil, c.ArgErr()
+				}
+				metrics.basicAuth = append(metrics.basicAuth, BasicAuth{username: args[0], password: args[1]})
 			default:
 				return nil, c.Errf("prometheus: unknown item: %s", c.Val())
 			}

--- a/setup_test.go
+++ b/setup_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"testing"
+	"reflect"
 
 	"github.com/mholt/caddy"
 )
@@ -69,7 +70,7 @@ func TestParse(t *testing.T) {
 		} else if !test.shouldErr && err != nil {
 			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
 		}
-		if test.expected != m && *test.expected != *m {
+		if reflect.DeepEqual(m, test.expected) == false {
 			t.Errorf("Test %v: Created Metrics (\n%#v\n) does not match expected (\n%#v\n)", i, m, test.expected)
 		}
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -47,6 +47,19 @@ func TestParse(t *testing.T) {
 			use_caddy_addr
 			hostname example.com
 		}`, false, &Metrics{useCaddyAddr: true, hostname: "example.com", addr: defaultAddr, path: defaultPath}},
+		{`prometheus {
+			basicauth samber qwerty
+			basicauth caddy issupercool
+		}`, false, &Metrics{addr: defaultAddr, path: defaultPath, basicAuth: []BasicAuth{{username: "samber", password: "qwerty"}, {username: "caddy", password: "issupercool"}}}},
+		{`prometheus {
+			basicauth samber
+		}`, true, nil},
+		{`prometheus {
+			basicauth
+		}`, true, nil},
+		{`prometheus {
+			basicauth /metrics samber qwerty
+		}`, true, nil},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("http", test.input)


### PR DESCRIPTION
Example:

```
# Caddyfile

  prometheus {
    basicauth my_username1 my_password1
    basicauth my_username2 my_password2
  }
 
```

```sh
#
# valid
#
$ curl localhost:80/metrics -u my_username1:my_password1
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 9
...

#
# invalid
#
$ curl localhost:80/metrics -u foo:bar -i
HTTP/1.1 401 Unauthorized
Content-Type: text/plain; charset=utf-8
Www-Authenticate: Basic realm="Restricted area"
X-Content-Type-Options: nosniff
Date: Tue, 13 Mar 2018 17:15:08 GMT
Content-Length: 13

Unauthorized
```