### PR TITLE
Correctly set "family" label (fixes #38)

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -42,8 +42,7 @@ func (m *Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error)
 	}
 
 	fam := "1"
-	ip := net.ParseIP(r.RemoteAddr)
-	if ip != nil && ip.To4() == nil {
+	if isIPv6(r.RemoteAddr) {
 		fam = "2"
 	}
 	proto := strconv.Itoa(r.ProtoMajor)
@@ -66,4 +65,13 @@ func host(r *http.Request) (string, error) {
 		return "", err
 	}
 	return strings.ToLower(host), nil
+}
+
+func isIPv6(addr string) bool {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		// Strip away the port.
+		addr = host
+	}
+	ip := net.ParseIP(addr)
+	return ip != nil && ip.To4() == nil
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -115,6 +115,28 @@ func TestMetrics_ServeHTTP(t *testing.T) {
 	}
 }
 
+func TestIsIPv6(t *testing.T) {
+	cases := []struct {
+		addr   string
+		isIPv6 bool
+	}{
+		{"", false},
+		{"192.0.2.42", false},
+		{"192.0.2.42:5678", false},
+		{"2001:db8::42", true},
+		{"[2001:db8::42]:5678", true},
+		{"banana", false},
+		{"banana::phone", false},
+	}
+
+	for _, tc := range cases {
+		res := isIPv6(tc.addr)
+		if res != tc.isIPv6 {
+			t.Errorf("isIPv6(%q) => %v, want %v", tc.addr, res, tc.isIPv6)
+		}
+	}
+}
+
 type testHandler struct{}
 
 func (h testHandler) ServeHTTP(_ http.ResponseWriter, r *http.Request) (int, error) {


### PR DESCRIPTION
The (*http.Request).RemoteAddr field contains the remote address with
port, so the plain ParseIP call always failed. This adds a helper
function that strips the port, yet also works if given an address
without port.