### PR TITLE
Refactor extra labels handling to structs

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -61,8 +61,8 @@ func (m *Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error)
 	replacer := httpserver.NewReplacer(r, rw, "")
 	var extraLabelValues []string
 
-	for _, value := range m.extraLabels {
-		extraLabelValues = append(extraLabelValues, replacer.Replace(value))
+	for _, label := range m.extraLabels {
+		extraLabelValues = append(extraLabelValues, replacer.Replace(label.value))
 	}
 
 	requestCount.WithLabelValues(append([]string{hostname, fam, proto}, extraLabelValues...)...).Inc()

--- a/setup.go
+++ b/setup.go
@@ -34,11 +34,16 @@ type Metrics struct {
 	useCaddyAddr bool
 	hostname     string
 	path         string
-	extraLabels  map[string]string
+	extraLabels  []extraLabel
 	// subsystem?
 	once sync.Once
 
 	handler http.Handler
+}
+
+type extraLabel struct {
+	name  string
+	value string
 }
 
 // NewMetrics -
@@ -46,7 +51,7 @@ func NewMetrics() *Metrics {
 	return &Metrics{
 		path:        defaultPath,
 		addr:        defaultAddr,
-		extraLabels: map[string]string{},
+		extraLabels: []extraLabel{},
 	}
 }
 
@@ -76,8 +81,8 @@ func (m *Metrics) start() error {
 func (m *Metrics) extraLabelNames() []string {
 	names := make([]string, 0, len(m.extraLabels))
 
-	for name := range m.extraLabels {
-		names = append(names, name)
+	for _, label := range m.extraLabels {
+		names = append(names, label.name)
 	}
 
 	return names
@@ -180,7 +185,7 @@ func parse(c *caddy.Controller) (*Metrics, error) {
 				labelName := strings.TrimSpace(args[0])
 				labelValuePlaceholder := args[1]
 
-				metrics.extraLabels[labelName] = labelValuePlaceholder
+				metrics.extraLabels = append(metrics.extraLabels, extraLabel{name: labelName, value: labelValuePlaceholder})
 			default:
 				return nil, c.Errf("prometheus: unknown item: %s", c.Val())
 			}

--- a/setup_test.go
+++ b/setup_test.go
@@ -13,8 +13,8 @@ func TestParse(t *testing.T) {
 		shouldErr bool
 		expected  *Metrics
 	}{
-		{`prometheus`, false, &Metrics{addr: defaultAddr, path: defaultPath, extraLabels: map[string]string{}}},
-		{`prometheus foo:123`, false, &Metrics{addr: "foo:123", path: defaultPath, extraLabels: map[string]string{}}},
+		{`prometheus`, false, &Metrics{addr: defaultAddr, path: defaultPath, extraLabels: []extraLabel{}}},
+		{`prometheus foo:123`, false, &Metrics{addr: "foo:123", path: defaultPath, extraLabels: []extraLabel{}}},
 		{`prometheus foo bar`, true, nil},
 		{`prometheus {
 			a b
@@ -40,18 +40,18 @@ func TestParse(t *testing.T) {
 		}`, true, nil},
 		{`prometheus {
 			use_caddy_addr
-		}`, false, &Metrics{useCaddyAddr: true, addr: defaultAddr, path: defaultPath, extraLabels: map[string]string{}}},
+		}`, false, &Metrics{useCaddyAddr: true, addr: defaultAddr, path: defaultPath, extraLabels: []extraLabel{}}},
 		{`prometheus {
 			path /foo
-		}`, false, &Metrics{addr: defaultAddr, path: "/foo", extraLabels: map[string]string{}}},
+		}`, false, &Metrics{addr: defaultAddr, path: "/foo", extraLabels: []extraLabel{}}},
 		{`prometheus {
 			use_caddy_addr
 			hostname example.com
-		}`, false, &Metrics{useCaddyAddr: true, hostname: "example.com", addr: defaultAddr, path: defaultPath, extraLabels: map[string]string{}}},
+		}`, false, &Metrics{useCaddyAddr: true, hostname: "example.com", addr: defaultAddr, path: defaultPath, extraLabels: []extraLabel{}}},
 		{`prometheus {
 			label version 1.2
 			label route_name {<X-Route-Name}
-		}`, false, &Metrics{addr: defaultAddr, path: defaultPath, extraLabels: map[string]string{"route_name": "{<X-Route-Name}", "version": "1.2"}}},
+		}`, false, &Metrics{addr: defaultAddr, path: defaultPath, extraLabels: []extraLabel{extraLabel{"version", "1.2"}, extraLabel{"route_name", "{<X-Route-Name}"}}}},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("http", test.input)


### PR DESCRIPTION
The current code assumes that multiple iterations over a map will be in the same order, but it is not guaranteed.

From the [Golang spec](https://golang.org/ref/spec#For_statements):

> The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next