### PR TITLE
Allow specifying custom latency and size buckets

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -18,6 +18,12 @@ func (m Metrics) define(subsystem string) {
 	if subsystem == "" {
 		subsystem = "http"
 	}
+	if m.latencyBuckets == nil {
+		m.latencyBuckets = append(prometheus.DefBuckets, 15, 20, 30, 60, 120, 180, 240, 480, 960)
+	}
+	if m.sizeBuckets == nil {
+		m.sizeBuckets = []float64{0, 500, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000, 1e5, 5e5, 1e6, 2e6, 3e6, 4e6, 5e6, 10e6}
+	}
 
 	extraLabels := m.extraLabelNames()
 
@@ -33,7 +39,7 @@ func (m Metrics) define(subsystem string) {
 		Subsystem: subsystem,
 		Name:      "request_duration_seconds",
 		Help:      "Histogram of the time (in seconds) each request took.",
-		Buckets:   append(prometheus.DefBuckets, 15, 20, 30, 60, 120, 180, 240, 480, 960),
+		Buckets:   m.latencyBuckets,
 	}, append([]string{"host", "family", "proto"}, extraLabels...))
 
 	responseSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -41,7 +47,7 @@ func (m Metrics) define(subsystem string) {
 		Subsystem: subsystem,
 		Name:      "response_size_bytes",
 		Help:      "Size of the returns response in bytes.",
-		Buckets:   []float64{0, 500, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000, 1e5, 5e5, 1e6, 2e6, 3e6, 4e6, 5e6, 10e6},
+		Buckets:   m.sizeBuckets,
 	}, append([]string{"host", "family", "proto", "status"}, extraLabels...))
 
 	responseStatus = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -56,6 +62,6 @@ func (m Metrics) define(subsystem string) {
 		Subsystem: subsystem,
 		Name:      "response_latency_seconds",
 		Help:      "Histogram of the time (in seconds) until the first write for each request.",
-		Buckets:   append(prometheus.DefBuckets, 15, 20, 30, 60, 120, 180, 240, 480, 960),
+		Buckets:   m.latencyBuckets,
 	}, append([]string{"host", "family", "proto", "status"}, extraLabels...))
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -52,6 +52,18 @@ func TestParse(t *testing.T) {
 			label version 1.2
 			label route_name {<X-Route-Name}
 		}`, false, &Metrics{addr: defaultAddr, path: defaultPath, extraLabels: []extraLabel{extraLabel{"version", "1.2"}, extraLabel{"route_name", "{<X-Route-Name}"}}}},
+		{`prometheus {
+			latency_buckets
+		}`, true, nil},
+		{`prometheus {
+			latency_buckets 0.1 2 5 10
+		}`, false, &Metrics{addr: defaultAddr, path: defaultPath, extraLabels: []extraLabel{}, latencyBuckets: []float64{0.1, 2, 5, 10}}},
+		{`prometheus {
+			size_buckets
+		}`, true, nil},
+		{`prometheus {
+			size_buckets 1 5 10 50 100 1e3 10e6
+		}`, false, &Metrics{addr: defaultAddr, path: defaultPath, extraLabels: []extraLabel{}, sizeBuckets: []float64{1, 5, 10, 50, 100, 1e3, 10e6}}},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("http", test.input)


### PR DESCRIPTION
Adds 2 new options: `size_buckets` and `latency_buckets`, which can be used to set custom bucket values for the latency and size histograms.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>