### PR TITLE
Fallthrough to embedded responsewriter's httpFlusher interface

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -118,3 +118,12 @@ func (w *timedResponseWriter) WriteHeader(statuscode int) {
 	w.didWrite()
 	w.ResponseWriter.WriteHeader(statuscode)
 }
+
+func (w *timedResponseWriter) Flush() {
+	flushableResponseWriter, ok := w.ResponseWriter.(http.Flusher)
+	if !ok {
+		return
+	}
+
+	flushableResponseWriter.Flush()
+}


### PR DESCRIPTION
This plugin breaks server-sent events proxying through caddy, because it breaks the httpFlusher interface and makes responses hang with a buffer. This change implements httpFlusher on the timedResponseWriter as a fallthrough to the embedded responsewriter, or no-op if unavailable.